### PR TITLE
feat: token last used timestamp

### DIFF
--- a/components/api-key-card.tsx
+++ b/components/api-key-card.tsx
@@ -61,7 +61,7 @@ export function ApiKeyCard() {
           projectAccess: "all",
           createdBy: userProfile.data.name,
           permissions: "all",
-          lastUsed: token.last_used_timestamp || "Never",
+          lastUsed: token.last_used_timestamp ? new Date(token.last_used_timestamp).toLocaleString() : "Never",
           id: token.id,
         };
       });

--- a/components/api-key-card.tsx
+++ b/components/api-key-card.tsx
@@ -61,7 +61,7 @@ export function ApiKeyCard() {
           projectAccess: "all",
           createdBy: userProfile.data.name,
           permissions: "all",
-          lastUsed: "_",
+          lastUsed: token.last_used_timestamp || "Never",
           id: token.id,
         };
       });

--- a/lib/atoma.ts
+++ b/lib/atoma.ts
@@ -22,6 +22,7 @@ export enum ModelModality {
 export interface Token {
   created_at: string; // Creation date of the token
   name: string; // Name of the token
+  last_used_timestamp: string;
   token_last_4: string; // Last 4 characters of the token
   id: number; // Unique identifier of the token
 }


### PR DESCRIPTION
Show last used timestamp for api tokens.
In case of old proxy, it will show `Never` no matter what.