### PR TITLE
feat: drop the (s) in modalities

### DIFF
--- a/app/models/page.tsx
+++ b/app/models/page.tsx
@@ -8,12 +8,12 @@ import { BackgroundGrid } from "@/components/background-grid";
 import { ApiUsageDialog } from "@/components/api-usage-dialog";
 import Link from "next/link";
 import { getSubscriptions, getTasks } from "@/lib/api";
-import { simplifyModelName } from "@/lib/utils";
+import { modalityToFeatureName, simplifyModelName } from "@/lib/utils";
 import { ModelModality, NodeSubscription, Task } from "@/lib/atoma";
 
 interface ModelSection {
   type: ModelModality;
-  title: ModelModality;
+  title: string;
   models: {
     name: string;
     price: string;
@@ -137,17 +137,17 @@ export default function ModelsPage() {
   const modelSections: ModelSection[] = [
     {
       type: ModelModality.ChatCompletions,
-      title: ModelModality.ChatCompletions,
+      title: modalityToFeatureName(ModelModality.ChatCompletions),
       models: modelsData[ModelModality.ChatCompletions],
     },
     {
       type: ModelModality.ImagesGenerations,
-      title: ModelModality.ImagesGenerations,
+      title: modalityToFeatureName(ModelModality.ImagesGenerations),
       models: modelsData[ModelModality.ImagesGenerations],
     },
     {
       type: ModelModality.Embeddings,
-      title: ModelModality.Embeddings,
+      title: modalityToFeatureName(ModelModality.Embeddings),
       models: modelsData[ModelModality.Embeddings],
     },
   ];
@@ -177,9 +177,15 @@ export default function ModelsPage() {
                 <SelectValue placeholder="Select completion type" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={ModelModality.ChatCompletions}>{ModelModality.ChatCompletions}</SelectItem>
-                <SelectItem value={ModelModality.ImagesGenerations}>{ModelModality.ImagesGenerations}</SelectItem>
-                <SelectItem value={ModelModality.Embeddings}>{ModelModality.Embeddings}</SelectItem>
+                <SelectItem value={ModelModality.ChatCompletions}>
+                  {modalityToFeatureName(ModelModality.ChatCompletions)}
+                </SelectItem>
+                <SelectItem value={ModelModality.ImagesGenerations}>
+                  {modalityToFeatureName(ModelModality.ImagesGenerations)}
+                </SelectItem>
+                <SelectItem value={ModelModality.Embeddings}>
+                  {modalityToFeatureName(ModelModality.Embeddings)}
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,7 @@ import type { UseMutateAsyncFunction } from "@tanstack/react-query";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import axios, { AxiosError } from "axios";
+import { ModelModality } from "./atoma";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -30,6 +31,19 @@ export function formatNumber(num?: number): string {
   }
   return num.toString();
 }
+
+export const modalityToFeatureName = (modality: ModelModality): string => {
+  switch (modality) {
+    case ModelModality.ChatCompletions:
+      return "Chat Completion";
+    case ModelModality.ImagesGenerations:
+      return "Image Generation";
+    case ModelModality.Embeddings:
+      return "Embedding";
+    default:
+      return modality;
+  }
+};
 
 const USDC_TYPE = process.env.NEXT_PUBLIC_USDC_TYPE;
 


### PR DESCRIPTION
Drop the `s` in modalities.
Instead of showing e.g. `chat completions` show `chat completion`.
This is for UI only, the modalities from proxy are still returned with the `s` because 