### PR TITLE
fix: update favicon and models page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,9 @@ export const metadata = {
   title: "AtomCloud Dashboard",
   description: "A modern, responsive financial dashboard",
   generator: "v0.dev",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <g fill="black">
+    <!-- Simplified Atoma logo with just the circles -->
+    <circle cx="8" cy="8" r="6"/>
+    <circle cx="24" cy="8" r="6"/>
+    <circle cx="8" cy="24" r="6"/>
+    <circle cx="24" cy="24" r="6"/>
+  </g>
+</svg> 


### PR DESCRIPTION
Updated the favicon to show Atoma's logo Closes #76 

Mades changes to the models page to show full model names but reverted as it is not a priority right now.