### PR TITLE
fix: the zk salt path endpoint has changed

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -173,7 +173,7 @@ export const googleOAuth = async (idToken: string) => {
 };
 
 export const getSalt = async () => {
-  return await credentialsApi.get<string>("/salt");
+  return await credentialsApi.get<string>("/zk_salt");
 };
 
 export const getGraphs = async () => {


### PR DESCRIPTION
The zk salt path has changed on proxy from `/salt` to `/zk_salt`. To make dashboard work this and the PR on proxy needs to be merged and deployed.
Closes #80 