### PR TITLE
feat: fill billing summary

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -296,7 +296,7 @@ function PanelData({
   type: string;
 }) {
   const unit = fieldConfig?.defaults?.unit;
-  const valueFormatter = (value: number) => (value ? `${formatNumber(value)}${unit ? ` ${unit}` : ""}` : "");
+  const valueFormatter = (value: number) => `${formatNumber(value)}${unit ? ` ${unit}` : ""}`;
   const graphData: Record<number, Record<string, string>> = {};
   const stackingGroup =
     fieldConfig?.defaults?.custom?.stacking?.mode != "none" && fieldConfig?.defaults?.custom?.stacking?.group;


### PR DESCRIPTION
Fill the billing summary (total api calls, total tokens)
Also fixes the empty string instead of zero on the graphs.
Closes #70 